### PR TITLE
Update plugin-publish-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = 1.7
 
 dependencies {
   compile "org.sonarqube.gradle:gradle-sonarqube-plugin:1.0"
-  compile "com.gradle.publish:plugin-publish-plugin:0.9.2"
+  compile "com.gradle.publish:plugin-publish-plugin:0.9.9"
   compile "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
 
   testCompile 'org.spockframework:spock-core:1.0-groovy-2.4', {


### PR DESCRIPTION
Hiya, I was doing a scan of the Gradle Plugin Portal and noticed you are using an old version of the `plugin-publish-plugin`.

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573), where artifacts would silently not be pushed into the repo.

**This plugin is fine in the portal**

However, your plugin https://github.com/iwarapter/gradle-openshift-plugin depends on this plugin, and as it is pulling an old version of the plugin-publish-plugin, version `0.1-RC2` will not work if pulled in to people's builds...

Upgrading to the latest version of the `plugin-publish-plugin` will fix this, but this will require pushing a new version of your plugin.

1. apply the PR
2. publish a new version of this `gradle-plugin-plugin` plugin
3. Update `gradle-openshift-plugin` to use the new `gradle-plugin-plugin` and publish a new version of that.
4. let us know if you want us to remove the broken version `0.1-RC2` of your `gradle-openshift-plugin`

Thanks (and sorry about that).

Let us know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.